### PR TITLE
Fixed socketio-serve-reload that did not find the socketio-serve-executable generated by a buildout

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,41 +1,71 @@
-0.8:
+Changelog
+=========
 
- - Fixed a bug when killing sessions.
+
+0.9 (unreleased)
+----------------
+
+- ``socketio-serve-reload`` did not not find the ``socketio-serve``-executable
+  in some cases.
+  [WouterVH]
 
 
-0.7:
+0.8 (2011-05-30)
+----------------
 
- - Added on_disconnect callbacks.
- - Improved kill() which will make it recursive by default, and call the on_disconnect callbacks.
- - spawn() now allows paramters (*args, **kwargs) to be passed in.
- - Improved documentation
- - msg() and error() now use send() which has all the connection state verification, and killing mechanism.
+- Fixed a bug when killing sessions.
 
-0.6:
 
- - Fixed a bug with .ini files with no logging sections (like formatters)
+0.7 (2011-05-17)
+----------------
 
-0.5:
+- Added on_disconnect callbacks.
 
- - Added JavaScript example.
- - Fixed setup.py (having not included CHANGES.txt in the sdist)
+- Improved kill() which will make it recursive by default, and call the on_disconnect callbacks.
 
-0.4
+- spawn() now allows paramters (*args, **kwargs) to be passed in.
 
- - Updated docs.
+- Improved documentation
 
-0.3
+- msg() and error() now use send() which has all the connection state verification, and killing mechanism.
 
- - CHANGES and README added to description.
 
-0.2
+0.6 (2011-05-11)
+----------------
 
- - Help updated
+- Fixed a bug with .ini files with no logging sections (like formatters)
 
-0.1
 
- - Initial release
- - Support for paster server plugin
- - Provide with command-line servers
-   - socketio-serve
-   - socketio-serve-reload
+0.5 (2011-02-15)
+----------------
+
+- Added JavaScript example.
+- Fixed setup.py (having not included CHANGES.txt in the sdist)
+
+
+0.4 (2011-02-15)
+----------------
+
+- Updated docs.
+
+
+0.3 (2011-02-15)
+----------------
+
+- CHANGES and README added to description.
+
+
+0.2 (2011-02-15)
+----------------
+
+- Help updated
+
+
+0.1 (2011-02-15)
+----------------
+
+- Initial release
+- Support for paster server plugin
+- Provide with command-line servers
+  - socketio-serve
+  - socketio-serve-reload

--- a/pyramid_socketio/io.py
+++ b/pyramid_socketio/io.py
@@ -3,20 +3,23 @@
 import logging
 import gevent
 
-__all__ = ['SocketIOError', 'SocketIOContext',
-           'socketio_manage']
+__all__ = ['SocketIOError', 'SocketIOContext', 'socketio_manage']
 
 log = logging.getLogger(__name__)
+
 
 class SocketIOError(Exception):
     pass
 
+
 class SocketIOKeyAssertError(SocketIOError):
     pass
 
+
 class SocketIOContext(object):
     def __init__(self, request, in_type="type", out_type="type", debug=False):
-        """Called when you create a new context, either by hand or from a nested context.
+        """Called when you create a new context, either by hand or from a
+           nested context.
 
         Arguments:
         * ``request`` - the pyramid request
@@ -42,7 +45,7 @@ class SocketIOContext(object):
 
         # Override self.debug if in production mode
         if not debug:
-             self.debug = lambda x: None
+            self.debug = lambda x: None
 
     def debug(self, msg):
         print "%s: %s" % (self.id, msg)
@@ -97,7 +100,6 @@ class SocketIOContext(object):
             if io:
                 io.session.kill()
             return
-            
 
     def switch(self, new_context, *args, **kwargs):
         """Switch context, stack up contexts and pass on request.
@@ -144,7 +146,6 @@ class SocketIOContext(object):
             raise gevent.GreenletExit()
         self.io.send(msg)
 
-
     def assert_keys(self, msg, elements):
         """Make sure the elements are inside the message, otherwise send an
         error message and skip the message.
@@ -174,7 +175,8 @@ class SocketIOContext(object):
 
 
 def watcher(request):
-    """Watch if any of the greenlets for a request have died. If so, kill the request and the socket.
+    """Watch if any of the greenlets for a request have died. If so, kill the
+       request and the socket.
     """
     # TODO: add that if any of the request.jobs die, kill them all and exit
     io = request.environ['socketio']
@@ -185,6 +187,7 @@ def watcher(request):
             # TODO: Warning, what about the on_disconnect callbacks ?
             gevent.killall(request.jobs)
             return
+
 
 def socketio_recv(context):
     """Manage messages arriving from Socket.IO, dispatch to context handler"""
@@ -210,6 +213,7 @@ def socketio_recv(context):
         if not io.connected():
             return
 
+
 def socketio_manage(start_context):
     """Main SocketIO management function, call from within your Pyramid view.
 
@@ -231,7 +235,7 @@ def socketio_manage(start_context):
     killall = gevent.spawn(watcher, request)
 
     gevent.joinall(request.jobs + [killall])
-    
+
     start_context.debug("socketio_manage terminated")
 
     return "done"

--- a/pyramid_socketio/pasteserve.py
+++ b/pyramid_socketio/pasteserve.py
@@ -9,6 +9,7 @@ from gevent.monkey import patch_all
 __all__ = ["server_factory",
            "server_factory_patched"]
 
+
 def server_factory(global_conf, host, port, resource="socket.io"):
     port = int(port)
     def serve(app):

--- a/pyramid_socketio/servereload.py
+++ b/pyramid_socketio/servereload.py
@@ -3,9 +3,15 @@
 import os
 import sys
 
+from os.path import dirname, join,realpath
+
+
 def socketio_serve_reload():
     """Spawn a new process and reload when it dies"""
+    bin_dir = dirname(realpath(sys.argv[0]))
+    executable = join(bin_dir, 'socketio-serve')
+    command = "%s --watch %s" % (executable, sys.argv[1])
     while True:
-        ret = os.system("socketio-serve --watch %s" % (sys.argv[1]))
+        ret = os.system(command)
         if ret != 768:
             break

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,8 @@ setup(name='pyramid_socketio',
       packages=find_packages(),
       include_package_data=True,
       zip_safe=False,
-      install_requires = requires,
-      entry_points = """\
+      install_requires=requires,
+      entry_points="""\
       [console_scripts]
       socketio-serve-reload = pyramid_socketio.servereload:socketio_serve_reload
       socketio-serve = pyramid_socketio.serve:socketio_serve


### PR DESCRIPTION
socketio-serve-reload did not not find the socketio-serve-executable in some cases + Minor PEP8/pyflakes-cleanup
