### PR TITLE
Call context.kill() (fire disconnect callbacks) when a websocket is no l...

### DIFF
--- a/pyramid_socketio/io.py
+++ b/pyramid_socketio/io.py
@@ -211,6 +211,7 @@ def socketio_recv(context):
                     context = newctx
 
         if not io.connected():
+            context.kill()
             return
 
 


### PR DESCRIPTION
...onger connected.
